### PR TITLE
fix: show panel for stories without an epic

### DIFF
--- a/components/IssuesPanel.vue
+++ b/components/IssuesPanel.vue
@@ -52,6 +52,7 @@
           </div>
 
           <div
+            v-if="data.fields.parent && data.fields.parent.fields"
             class="rounded-md bg-blue-400 px-2 py-1 text-sm text-white dark:bg-blue-500/20 dark:text-blue-200"
           >
             {{ data.fields.parent.fields.summary }}


### PR DESCRIPTION
**Summary of Changes**

If no epic panel failed to open

BEFORE

https://github.com/user-attachments/assets/8ff52350-a451-4c32-bf4e-07dd819050ef



AFTER


https://github.com/user-attachments/assets/c51f9d49-1e9e-4dc9-947d-0b0d88379579

